### PR TITLE
Match newline characters too

### DIFF
--- a/src/lib/index.coffee
+++ b/src/lib/index.coffee
@@ -15,14 +15,14 @@ module.exports = (text) ->
   exp = ///
     ^From:\s* #{emailReg}               # From: test@test.com
     | ^<#{emailReg}>                    # <test@test.com>
-    | ^On .* wrote:                     # On Fri, May 25, 2012 at 1:33 PM, xxx wrote:
-    | ^Le .* #{'a écrit :'}             # Le 12 juin 2012 à 17:50, xxx a écrit :"
+    | ^On [\S\s]* wrote:                     # On Fri, May 25, 2012 at 1:33 PM, xxx wrote:
+    | ^Le [\S\s]* #{'a écrit :'}             # Le 12 juin 2012 à 17:50, xxx a écrit :"
     | ^-+original \s+ message-+         # ---Original Message---
     | ^Sent .* from .* my .*            # Sent from my Iphone
     | ^envoyé \s+ depuis \s+ mon .*     # Envoye depuis my Iphone
     | ^envoyé \s+ de \s+ mon .*         # Envoye depuis de mon ipad
     | ^#{'reply above this line'}       # reply ABOVE THIS LINE
-    | ^--\n .*                          # -- signature
+    | ^--\n [\S\s]*                          # -- signature
   ///gmi
 
   m = exp.exec text


### PR DESCRIPTION
Here's an example of a reply from Gmail:

'This is weird.\n\nOn Tue, Oct 2, 2012 at 1:18 PM, Image Description <\nsomeone@domain.com> wrote:\n\n> Here\'s the image to describe (click to enlarge):\n>\n>\n'

Sometimes there's a newline in the middle of the 'On …, … wrote:', and the dot (.) matches any character _except_ a newline. [\S\s] will match any character including the newline.
